### PR TITLE
添加一项延迟发送带生命周期判断的功能

### DIFF
--- a/live-event-bus/app/src/main/AndroidManifest.xml
+++ b/live-event-bus/app/src/main/AndroidManifest.xml
@@ -10,14 +10,16 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="com.jeremyliao.lebapp.LiveEventBusDemo">
+        <activity android:name=".activity.PostDelayActivity"/>
+        <activity android:name=".LiveEventBusDemo">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
+
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name="com.jeremyliao.lebapp.activity.StickyActivity" />
-        <activity android:name="com.jeremyliao.lebapp.activity.TestActivity" />
+        <activity android:name=".activity.StickyActivity" />
+        <activity android:name=".activity.TestActivity" />
         <activity android:name=".activity.ObserverActiveLevelActivity" />
 
         <service

--- a/live-event-bus/app/src/main/java/com/jeremyliao/lebapp/LiveEventBusDemo.java
+++ b/live-event-bus/app/src/main/java/com/jeremyliao/lebapp/LiveEventBusDemo.java
@@ -10,6 +10,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.widget.Toast;
 
 import com.jeremyliao.lebapp.activity.ObserverActiveLevelActivity;
+import com.jeremyliao.lebapp.activity.PostDelayActivity;
 import com.jeremyliao.lebapp.activity.StickyActivity;
 import com.jeremyliao.lebapp.databinding.ActivityLiveDataBusDemoBinding;
 import com.jeremyliao.lebapp.service.IpcService;
@@ -33,11 +34,12 @@ public class LiveEventBusDemo extends AppCompatActivity {
     public static final String KEY_TEST_CLOSE_ALL_PAGE = "key_test_close_all_page";
     public static final String KEY_TEST_ACTIVE_LEVEL = "key_test_active_level";
     public static final String KEY_TEST_BROADCAST = "key_test_broadcast";
-
+    public static final String KEY_TEST_DELAY_LIFE = "key_test_delay_life";
 
     private int sendCount = 0;
     private int receiveCount = 0;
     private String randomKey = null;
+
 
     private ActivityLiveDataBusDemoBinding binding;
 
@@ -86,6 +88,16 @@ public class LiveEventBusDemo extends AppCompatActivity {
                 });
         LiveEventBus
                 .get(KEY_TEST_ACTIVE_LEVEL, String.class)
+                .observe(this, new Observer<String>() {
+                    @Override
+                    public void onChanged(@Nullable String s) {
+                        Toast.makeText(LiveEventBusDemo.this, "Receive message: " + s,
+                                Toast.LENGTH_SHORT).show();
+                    }
+                });
+
+        LiveEventBus
+                .get(KEY_TEST_DELAY_LIFE, String.class)
                 .observe(this, new Observer<String>() {
                     @Override
                     public void onChanged(@Nullable String s) {
@@ -229,4 +241,9 @@ public class LiveEventBusDemo extends AppCompatActivity {
                 .get(KEY_TEST_BROADCAST)
                 .broadcast("broadcast msg");
     }
+
+    public void testDelayLife() {
+        startActivity(new Intent(this, PostDelayActivity.class));
+    }
+
 }

--- a/live-event-bus/app/src/main/java/com/jeremyliao/lebapp/activity/PostDelayActivity.java
+++ b/live-event-bus/app/src/main/java/com/jeremyliao/lebapp/activity/PostDelayActivity.java
@@ -17,7 +17,7 @@ import com.jeremyliao.liveeventbus.LiveEventBus;
 public class PostDelayActivity extends AppCompatActivity {
 
     ActivityPostDelayBinding binding;
-    private int sendCount = 50;
+    private int sendCount = 1000;
     private int receiveCount = 0;
     public static final String KEY_TEST_DELAY_LIFE_LONG = "key_test_delay_life_long";
 
@@ -35,11 +35,10 @@ public class PostDelayActivity extends AppCompatActivity {
                     @Override
                     public void onChanged(@Nullable String s) {
                         Toast.makeText(PostDelayActivity.this,
-                                " | receiveCount: " + receiveCount, Toast.LENGTH_SHORT).show();
+                                "receiveCount: " + receiveCount, Toast.LENGTH_SHORT).show();
                         receiveCount++;
                     }
                 });
-
     }
 
     public void  testDelayNoLife(View view){

--- a/live-event-bus/app/src/main/java/com/jeremyliao/lebapp/activity/PostDelayActivity.java
+++ b/live-event-bus/app/src/main/java/com/jeremyliao/lebapp/activity/PostDelayActivity.java
@@ -1,0 +1,75 @@
+package com.jeremyliao.lebapp.activity;
+
+import android.arch.lifecycle.Observer;
+import android.databinding.DataBindingUtil;
+import android.os.Handler;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.Toast;
+
+import com.jeremyliao.lebapp.LiveEventBusDemo;
+import com.jeremyliao.lebapp.R;
+import com.jeremyliao.lebapp.databinding.ActivityPostDelayBinding;
+import com.jeremyliao.liveeventbus.LiveEventBus;
+
+public class PostDelayActivity extends AppCompatActivity {
+
+    ActivityPostDelayBinding binding;
+    private int sendCount = 50;
+    private int receiveCount = 0;
+    public static final String KEY_TEST_DELAY_LIFE_LONG = "key_test_delay_life_long";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_post_delay);
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_post_delay);
+        binding.setLifecycleOwner(this);
+        binding.setHandler(this);
+
+        LiveEventBus
+                .get(KEY_TEST_DELAY_LIFE_LONG, String.class)
+                .observe(this, new Observer<String>() {
+                    @Override
+                    public void onChanged(@Nullable String s) {
+                        Toast.makeText(PostDelayActivity.this,
+                                " | receiveCount: " + receiveCount, Toast.LENGTH_SHORT).show();
+                        receiveCount++;
+                    }
+                });
+
+    }
+
+    public void  testDelayNoLife(View view){
+        LiveEventBus
+                .get(LiveEventBusDemo.KEY_TEST_DELAY_LIFE)
+                .postDelay("Send Msg To Observer Delay 2s",2000);
+        finish();
+    }
+
+
+    public void testDelayWithLife(View view){
+        LiveEventBus
+                .get(LiveEventBusDemo.KEY_TEST_DELAY_LIFE)
+                .postDelay(this,"Send Msg To Observer Delay 2s",2000);
+        finish();
+    }
+
+    public void testDelayWithLifeLast(View view){
+        for(int i= 0;i< sendCount;i++){
+            LiveEventBus
+                    .get(KEY_TEST_DELAY_LIFE_LONG)
+                    .postDelay(this,"Send " + i + " Msg To Observer Delay 2s",2000);
+        }
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                Toast.makeText(PostDelayActivity.this, "sendCount: " + sendCount +
+                        " | receiveCount: " + receiveCount, Toast.LENGTH_LONG).show();
+            }
+        }, 3000);
+    }
+
+}

--- a/live-event-bus/app/src/main/res/layout/activity_live_data_bus_demo.xml
+++ b/live-event-bus/app/src/main/res/layout/activity_live_data_bus_demo.xml
@@ -104,6 +104,12 @@
                 android:onClick="@{()->handler.testBroadcast()}"
                 android:text="测试跨进程发送消息" />
 
+            <Button
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:gravity="center"
+                android:onClick="@{()->handler.testDelayLife()}"
+                android:text="测试延迟发送带生命周期" />
         </LinearLayout>
     </ScrollView>
 </layout>

--- a/live-event-bus/app/src/main/res/layout/activity_post_delay.xml
+++ b/live-event-bus/app/src/main/res/layout/activity_post_delay.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <data>
+        <variable
+            name="Handler"
+            type="com.jeremyliao.lebapp.activity.PostDelayActivity" />
+    </data>
+
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:app="http://schemas.android.com/apk/res-auto"
+        xmlns:tools="http://schemas.android.com/tools"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        tools:context="com.jeremyliao.lebapp.activity.PostDelayActivity">
+
+        <Button
+            android:onClick="@{Handler::testDelayNoLife}"
+            android:text="发送延迟2s不带生命周期"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+        <Button
+            android:onClick="@{Handler::testDelayWithLife}"
+            android:text="发送延迟2s带生命周期"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+        <Button
+            android:onClick="@{Handler::testDelayWithLifeLast}"
+            android:text="连续多次发送延迟2s带生命周期"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
+
+    </LinearLayout>
+</layout>

--- a/live-event-bus/liveeventbus/src/main/java/com/jeremyliao/liveeventbus/core/LiveEventBusCore.java
+++ b/live-event-bus/liveeventbus/src/main/java/com/jeremyliao/liveeventbus/core/LiveEventBusCore.java
@@ -13,7 +13,6 @@ import android.os.Looper;
 import android.support.annotation.MainThread;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.util.Log;
 
 import com.jeremyliao.liveeventbus.ipc.IpcConst;
 import com.jeremyliao.liveeventbus.ipc.encode.IEncoder;
@@ -27,9 +26,6 @@ import com.jeremyliao.liveeventbus.utils.ThreadUtils;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.logging.Level;
 
 /**

--- a/live-event-bus/liveeventbus/src/main/java/com/jeremyliao/liveeventbus/core/Observable.java
+++ b/live-event-bus/liveeventbus/src/main/java/com/jeremyliao/liveeventbus/core/Observable.java
@@ -32,6 +32,17 @@ public interface Observable<T> {
      */
     void postDelay(T value, long delay);
 
+
+    /**
+     * 延迟发送一个消息，支持前台线程、后台线程发送,带生命监听
+     *
+     * @param owner LifecycleOwner实现生命监听
+     * @param value
+     * @param delay 延迟毫秒数
+     */
+    void postDelay(LifecycleOwner owner,T value, long delay);
+
+
     /**
      * 发送一个消息，支持前台线程、后台线程发送
      * 接收到消息的顺序和发送顺序一致


### PR DESCRIPTION
添加一项延迟发送带生命周期判断的功能
添加： Observable<T> 下新增 postDelay(LifecycleOwner owner,T value, long delay)
 LiveEventBusCore 下实现该方法，并增加一个PostLifeValueTask，实现延迟发送
并在Demo内新增了一个测试入口，及对应增加三个测试内容

目前发现的可能用到场景：当延迟的推送需要与页面的活动生命周期关联上，当活动销毁后，不发送延迟的消息
目前处理手法的问题：发送由于需要利用到LifecycleOwner，所以使用时候需要拿到LifecycleOwner或者实现LifecycleOwner并在相应绑定生命的地方实现addObserver等