### PR TITLE
适配Android 14

### DIFF
--- a/branchs/live-event-bus-x/app/build.gradle
+++ b/branchs/live-event-bus-x/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 34
     defaultConfig {
         applicationId "com.jeremyliao.livedatabus"
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/branchs/live-event-bus-x/app/src/main/AndroidManifest.xml
+++ b/branchs/live-event-bus-x/app/src/main/AndroidManifest.xml
@@ -10,7 +10,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
-        <activity android:name="com.jeremyliao.lebapp.LiveEventBusDemo">
+        <activity
+            android:name="com.jeremyliao.lebapp.LiveEventBusDemo"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/branchs/live-event-bus-x/lebx-processor-gson/build.gradle
+++ b/branchs/live-event-bus-x/lebx-processor-gson/build.gradle
@@ -3,11 +3,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }

--- a/branchs/live-event-bus-x/liveeventbus-x/build.gradle
+++ b/branchs/live-event-bus-x/liveeventbus-x/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 28
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }

--- a/branchs/live-event-bus-x/liveeventbus-x/src/main/java/com/jeremyliao/liveeventbus/core/LiveEventBusCore.java
+++ b/branchs/live-event-bus-x/liveeventbus-x/src/main/java/com/jeremyliao/liveeventbus/core/LiveEventBusCore.java
@@ -1,6 +1,7 @@
 package com.jeremyliao.liveeventbus.core;
 
 import android.app.Application;
+import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Build;
@@ -95,6 +96,7 @@ public final class LiveEventBusCore {
      * first of all, call config to get the Config instance
      * then, call the method of Config to config LiveEventBus
      * call this method in Application.onCreate
+     *
      * @return Config
      */
     public Config config() {
@@ -124,7 +126,11 @@ public final class LiveEventBusCore {
         if (application != null) {
             IntentFilter intentFilter = new IntentFilter();
             intentFilter.addAction(IpcConst.ACTION);
-            application.registerReceiver(receiver, intentFilter);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                application.registerReceiver(receiver, intentFilter, Context.RECEIVER_EXPORTED);
+            } else {
+                application.registerReceiver(receiver, intentFilter);
+            }
             isRegisterReceiver = true;
         }
     }

--- a/live-event-bus/app/build.gradle
+++ b/live-event-bus/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 34
     defaultConfig {
         applicationId "com.jeremyliao.livedatabus"
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/live-event-bus/app/src/main/AndroidManifest.xml
+++ b/live-event-bus/app/src/main/AndroidManifest.xml
@@ -11,7 +11,9 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity android:name=".activity.PostDelayActivity" />
-        <activity android:name=".LiveEventBusDemo">
+        <activity
+            android:name=".LiveEventBusDemo"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/live-event-bus/leb-processor-gson/build.gradle
+++ b/live-event-bus/leb-processor-gson/build.gradle
@@ -3,11 +3,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }

--- a/live-event-bus/liveeventbus/build.gradle
+++ b/live-event-bus/liveeventbus/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 
 
 android {
-    compileSdkVersion 27
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 27
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
     }

--- a/live-event-bus/liveeventbus/src/main/java/com/jeremyliao/liveeventbus/core/LiveEventBusCore.java
+++ b/live-event-bus/liveeventbus/src/main/java/com/jeremyliao/liveeventbus/core/LiveEventBusCore.java
@@ -6,6 +6,7 @@ import android.arch.lifecycle.Lifecycle;
 import android.arch.lifecycle.LifecycleOwner;
 import android.arch.lifecycle.LiveData;
 import android.arch.lifecycle.Observer;
+import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Build;
@@ -94,6 +95,7 @@ public final class LiveEventBusCore {
      * first of all, call config to get the Config instance
      * then, call the method of Config to config LiveEventBus
      * call this method in Application.onCreate
+     *
      * @return Config
      */
     public Config config() {
@@ -123,7 +125,11 @@ public final class LiveEventBusCore {
         if (application != null) {
             IntentFilter intentFilter = new IntentFilter();
             intentFilter.addAction(IpcConst.ACTION);
-            application.registerReceiver(receiver, intentFilter);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                application.registerReceiver(receiver, intentFilter, Context.RECEIVER_EXPORTED);
+            } else {
+                application.registerReceiver(receiver, intentFilter);
+            }
             isRegisterReceiver = true;
         }
     }


### PR DESCRIPTION
1. 动态注册广播指定导出行为，谷歌官方提供了一个 `registerReceiver(BroadcastReceiver receiver, IntentFilter filter, int flags) `API，`flags` 参数传入 `Context.RECEIVER_EXPORTED`（支持导出） 。

   本次修改主要对`com.jeremyliao.liveeventbus.core.LiveEventBusCore#registerReceiver`方法进行修改，注册广播时，当安卓系统版本大于等于14，传入`Context.RECEIVER_EXPORTED`参数
